### PR TITLE
chore: Update MongoDB Docker image to latest version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - bridge
 
   mongo:
-    image: mongo:4.2
+    image: mongo:latest
     ports:
       - "27017:27017"
     volumes:


### PR DESCRIPTION
ラズパイ用に実施したが、効果がなかったこと、個別の環境差異であるため各自で調整する必要上がるため、いったん元のに戻すこととした